### PR TITLE
Skin shortcuts integration to add music node to main menu

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -288,8 +288,10 @@ class Main:
             commandsNode.append( ( __language__(30104), "XBMC.RunPlugin(plugin://plugin.library.node.editor?ltype=%s&type=editorder&actionPath=" % ltype + os.path.join( nodes[ key ][ 2 ], "index.xml" ) + ")" ) )
             commandsNode.append( ( __language__(30105), "XBMC.RunPlugin(plugin://plugin.library.node.editor?ltype=%s&type=editvisibility&actionPath=" % ltype + os.path.join( nodes[ key ][ 2 ], "index.xml" ) + ")" ) )
             commandsNode.append( ( __language__(30100), "XBMC.RunPlugin(plugin://plugin.library.node.editor?ltype=%s&type=delete&actionPath=" % ltype + nodes[ key ][ 2 ] + ")" ) )
-            if showAddToMenu:
+            if showAddToMenu and "video" in targetDir:
                 commandsNode.append( ( __language__(30106), "XBMC.RunScript(script.skinshortcuts,type=addNode&options=" + urllib.unquote( nodes[ key ][ 2 ] ).replace( targetDir, "" ) + "|" + urllib.quote( label.encode( "utf-8" ) ) + "|" + urllib.quote( nodes[ key ][ 1 ].encode( "utf-8" ) ) + ")" ) )
+            elif showAddToMenu and "music" in targetDir:
+                commandsNode.append( ( __language__(30106), "XBMC.RunScript(script.skinshortcuts,type=addMusicNode&options=" + urllib.unquote( nodes[ key ][ 2 ] ).replace( targetDir, "" ) + "|" + urllib.quote( label.encode( "utf-8" ) ) + "|" + urllib.quote( nodes[ key ][ 1 ].encode( "utf-8" ) ) + ")" ) )
             commandsView.append( ( __language__(30101), "XBMC.RunPlugin(plugin://plugin.library.node.editor?ltype=%s&type=editlabel&actionPath=" % ltype + nodes[ key ][ 2 ] + "&label=" + nodes[ key ][ 0 ] + ")" ) )
             commandsView.append( ( __language__(30102), "XBMC.RunPlugin(plugin://plugin.library.node.editor?ltype=%s&type=editIcon&actionPath=" % ltype + nodes[ key ][ 2 ] + "&value=" + nodes[ key ][ 1 ] + ")" ) )
             commandsView.append( ( __language__(30103), "XBMC.RunPlugin(plugin://plugin.library.node.editor?ltype=%s&type=browseIcon&actionPath=" % ltype + nodes[ key ][ 2 ] + ")" ) )


### PR DESCRIPTION
Updates scripts integration with the skin shortcuts script to add a music node to the main menu of any skin which uses skin shortcuts to manage its main menu from the context menu.

I don't know how you want to proceed with this PR, as it is reliant on https://github.com/BigNoid/script.skinshortcuts/pull/66 to work correctly. There is currently a repo update request open, so it is likely it will be a while before that PR makes it onto the repo. Let me know if you prefer to wait to merge this change, or simply to refrain from making a PR of this script until a PR of the Skin Shortcuts script is made, and (if it's useful), I'll be happy to let you know when that script has a repo request with the relevant PR open so that this script can be updated in tandem.