### PR TITLE
Allow editing match element of rule based nodes

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -133,7 +133,11 @@ msgctxt "#30205"
 msgid "Rule"
 msgstr ""
 
-#empty strings from id 30206 to 30299
+msgctxt "#30206"
+msgid "Match"
+msgstr ""
+
+#empty strings from id 30207 to 30299
 
 # Titles for dialogs
 msgctxt "#30300"

--- a/resources/lib/viewattrib.py
+++ b/resources/lib/viewattrib.py
@@ -314,6 +314,22 @@ class ViewAttribFunctions():
 
         return returnString
 
+    def translateMatch( self, value ):
+        if value == "any":
+            return xbmc.getLocalizedString(21426).capitalize()
+        else:
+            return xbmc.getLocalizedString(21425).capitalize()
+
+    def editMatch( self, actionPath ):
+        selectName = [ xbmc.getLocalizedString(21425).capitalize(), xbmc.getLocalizedString(21426).capitalize() ]
+        selectValue = [ "all", "any" ]
+        # Let the user select wether any or all rules need match
+        selectedMatch = xbmcgui.Dialog().select( LANGUAGE( 30310 ), selectName )
+        # If the user made no selection...
+        if selectedMatch == -1:
+            return
+        self.writeUpdatedRule( actionPath, "match", selectValue[ selectedMatch ] )
+
     # in-place prettyprint formatter
     def indent( self, elem, level=0 ):
         i = "\n" + level*"\t"


### PR DESCRIPTION
Allows editing the <match> element of a rule-based node, with the potential values 'any' or 'all' dependant on whether any or all of the rules must match when there are 2 or more rules.

Previously, all nodes created with the editor could only use Kodi's default behaviour whereby all of the rules must match.