### PR TITLE
Plugin path support

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -350,6 +350,7 @@ class Main:
         xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=%s&type=newNode&actionPath=" % ltype + self.PATH, xbmcgui.ListItem( label=LANGUAGE(30007) ), isFolder=False )
         if showReset:
             xbmcplugin.addDirectoryItem( int(sys.argv[ 1 ]), "plugin://plugin.library.node.editor?ltype=%s&type=delete&actionPath=" % ltype + targetDir, xbmcgui.ListItem( label=LANGUAGE(30008) ), isFolder=False )
+        xbmcplugin.setContent(int(sys.argv[1]), 'files')
         xbmcplugin.endOfDirectory(handle=int(sys.argv[1]))
 
     def RulesList( self ):
@@ -480,6 +481,7 @@ class Main:
                 xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=%s&type=pathRule&actionPath=%s&rule=%d" % ( ltype, self.PATH, x + 1 ), xbmcgui.ListItem( label=LANGUAGE(30009) ), isFolder = True )
             # Manually edit path
             xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=%s&type=editPath&actionPath=" % ltype + self.PATH + "&value=" + rule[ 1 ], xbmcgui.ListItem( label=LANGUAGE(30010) ), isFolder = True )
+        xbmcplugin.setContent(int(sys.argv[1]), 'files')
         xbmcplugin.endOfDirectory(handle=int(sys.argv[1]))
 
     def _parse_argv( self ):
@@ -797,6 +799,7 @@ if ( __name__ == "__main__" ):
     if sys.argv[2] == '':
         xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=video", xbmcgui.ListItem( label=LANGUAGE(30091) ), isFolder=True )
         xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=music", xbmcgui.ListItem( label=LANGUAGE(30092) ), isFolder=True )
+        xbmcplugin.setContent(int(sys.argv[1]), 'files')
         xbmcplugin.endOfDirectory(handle=int(sys.argv[1]))
     else:
         params = dict( arg.split( "=" ) for arg in sys.argv[ 2 ][1:].split( "&" ) )

--- a/addon.py
+++ b/addon.py
@@ -361,6 +361,7 @@ class Main:
         hasGroup = False
         hasLimit = False
         hasPath = False
+        splitPath = None
         rulecount = 0
         self.PATH = self.PATH
         if rules is not None:
@@ -474,8 +475,9 @@ class Main:
             # Add rule
             xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=%s&type=rule&actionPath=" % ltype + self.PATH + "&rule=" + str( nextRule ), xbmcgui.ListItem( label=LANGUAGE(30005) ), isFolder = True )
         if hasPath:
-            # Add component
-            xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=%s&type=pathRule&actionPath=%s&rule=%d" % ( ltype, self.PATH, x + 1 ), xbmcgui.ListItem( label=LANGUAGE(30009) ), isFolder = True )
+            if "plugin://" not in splitPath[0][0]:
+                # Add component
+                xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=%s&type=pathRule&actionPath=%s&rule=%d" % ( ltype, self.PATH, x + 1 ), xbmcgui.ListItem( label=LANGUAGE(30009) ), isFolder = True )
             # Manually edit path
             xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=%s&type=editPath&actionPath=" % ltype + self.PATH + "&value=" + rule[ 1 ], xbmcgui.ListItem( label=LANGUAGE(30010) ), isFolder = True )
         xbmcplugin.endOfDirectory(handle=int(sys.argv[1]))

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -259,7 +259,15 @@ msgctxt "#30409"
 msgid "No options to select from were found"
 msgstr ""
 
-#empty strings from id 30410 to 30499
+msgctxt "#30410"
+msgid "Getting plugin listings..."
+msgstr ""
+
+msgctxt "#30411"
+msgid "Link path to here"
+msgstr ""
+
+#empty strings from id 30412 to 30499
 
 # Labels for path rules
 
@@ -317,4 +325,8 @@ msgstr ""
 
 msgctxt "#30513"
 msgid "Show singles"
+msgstr ""
+
+msgctxt "#30514"
+msgid "Plugin..."
 msgstr ""

--- a/resources/lib/orderby.py
+++ b/resources/lib/orderby.py
@@ -88,6 +88,7 @@ class OrderByFunctions():
             listitem = xbmcgui.ListItem( label="%s" % ( translated[ 1 ][ 0 ] ) )
             action = "plugin://plugin.library.node.editor?ltype=%s&type=editOrderByDirection&actionPath=" % ltype + actionPath + "&default=" + translated[ 1 ][ 1 ]
             xbmcplugin.addDirectoryItem( int(sys.argv[ 1 ]), action, listitem, isFolder=False )
+            xbmcplugin.setContent(int(sys.argv[1]), 'files')
             xbmcplugin.endOfDirectory(handle=int(sys.argv[1]))
         except:
             print_exc()

--- a/resources/lib/pathrules.py
+++ b/resources/lib/pathrules.py
@@ -110,6 +110,7 @@ class PathRuleFunctions():
                 action = "plugin://plugin.library.node.editor?ltype=%s&type=browsePathValue&actionPath=%s&rule=%s" %( ltype, actionPath, ruleNum )
                 xbmcplugin.addDirectoryItem( int(sys.argv[ 1 ]), action, listitem, isFolder=False )
 
+            xbmcplugin.setContent(int(sys.argv[1]), 'files')
             xbmcplugin.endOfDirectory(handle=int(sys.argv[1]))
             return
         except:

--- a/resources/lib/pluginBrowser.py
+++ b/resources/lib/pluginBrowser.py
@@ -1,0 +1,65 @@
+# coding=utf-8
+import sys
+import xbmc, xbmcaddon, xbmcgui
+import json
+
+ADDON        = xbmcaddon.Addon()
+ADDONID      = ADDON.getAddonInfo('id').decode( 'utf-8' )
+LANGUAGE     = ADDON.getLocalizedString
+ADDONNAME    = ADDON.getAddonInfo('name').decode("utf-8")
+ltype        = sys.modules[ '__main__' ].ltype
+
+def log(txt):
+    if isinstance (txt,str):
+        txt = txt.decode('utf-8')
+    message = u'%s: %s' % (ADDONID, txt)
+    xbmc.log(msg=message.encode('utf-8'), level=xbmc.LOGDEBUG)
+
+def getPluginPath( location = None ):
+    listings = []
+    listingsLabels = []
+
+    if location is not None:
+        # If location given, add 'create' item
+        listings.append( "::CREATE::" )
+        listingsLabels.append( LANGUAGE( 30411 ) )
+    else:
+        # If no location, build default
+        if location is None:
+            if ltype == "video":
+                location = "addons://sources/video"
+            else:
+                location = "addons://sources/audio"
+
+    # Show a waiting dialog, then get the listings for the directory
+    dialog = xbmcgui.DialogProgress()
+    dialog.create( ADDONNAME, LANGUAGE( 30410 ) )
+    
+    json_query = xbmc.executeJSONRPC('{ "jsonrpc": "2.0", "id": 0, "method": "Files.GetDirectory", "params": { "properties": ["title", "file", "thumbnail", "episode", "showtitle", "season", "album", "artist", "imdbnumber", "firstaired", "mpaa", "trailer", "studio", "art"], "directory": "' + location + '", "media": "files" } }')
+    json_query = unicode(json_query, 'utf-8', errors='ignore')
+    json_response = json.loads(json_query)
+        
+    # Add all directories returned by the json query
+    if json_response.has_key('result') and json_response['result'].has_key('files') and json_response['result']['files']:
+        json_result = json_response['result']['files']
+        
+        for item in json_result:
+            if item[ "file" ].startswith( "plugin://" ):
+                listings.append( item[ "file" ] )
+                listingsLabels.append( "%s >" %( item[ "label" ] ) )
+        
+    # Close progress dialog
+    dialog.close()
+
+    selectedItem = xbmcgui.Dialog().select( LANGUAGE( 30309 ), listingsLabels )
+
+    if selectedItem == -1:
+        # User cancelled
+        return None
+    
+    selectedAction = listings[ selectedItem ]
+    if selectedAction == "::CREATE::":
+        return location
+    else:
+        # User has chosen a sub-level to display, add details and re-call this function
+        return getPluginPath( selectedAction )

--- a/resources/lib/rules.py
+++ b/resources/lib/rules.py
@@ -120,6 +120,7 @@ class RuleFunctions():
                                 action = "plugin://plugin.library.node.editor?ltype=%s&type=browseValue&actionPath=" % ltype + actionPath + "&rule=" + str( ruleCount ) + "&match=" + translated[ 0 ][ 1 ] + "&content=" + content
                                 xbmcplugin.addDirectoryItem( int(sys.argv[ 1 ]), action, listitem, isFolder=False )
                             #self.browse( translated[ 0 ][ 1 ], content )
+                        xbmcplugin.setContent(int(sys.argv[1]), 'files')
                         xbmcplugin.endOfDirectory(handle=int(sys.argv[1]))
                         return
                     ruleCount = ruleCount + 1
@@ -445,6 +446,7 @@ class RuleFunctions():
                             action = "plugin://plugin.library.node.editor?ltype=%s&type=browseValue&actionPath=" % ltype + actionPath + "&rule=" + str( ruleCount ) + "&match=" + translated[ 0 ][ 1 ] + "&content=NONE"
                             xbmcplugin.addDirectoryItem( int(sys.argv[ 1 ]), action, listitem, isFolder=False )
                         #self.browse( translated[ 0 ][ 1 ], content )
+                    xbmcplugin.setContent(int(sys.argv[1]), 'files')
                     xbmcplugin.endOfDirectory(handle=int(sys.argv[1]))
                     return
                 ruleCount += 1


### PR DESCRIPTION
As requested by @HitcherUK, adds support for browsing plugins nodes to use as the path in a path-based node.

Also, as discussed with Phil in the Estuary feature requests thread, sets the content type to 'files' to enable a list-style view for the plugin in that skin.

These should be the last changes I make to the script for the foreseeable future, barring any bugs.

Thanks.