### PR TITLE
Enable browse for value for music role

### DIFF
--- a/resources/musicrules.xml
+++ b/resources/musicrules.xml
@@ -250,11 +250,13 @@
 			<value>integer</value>
 			<content>artists</content>
 			<content>albums</content>
+			<browse>musicdb://roles/</browse>
 		</rule>
 		<rule name="role" label="38033">
 			<value>string</value>
 			<content>artists</content>
 			<content>albums</content>
+			<browse>musicdb://roles/</browse>
 		</rule>
 		<rule name="artistid" label="30508">
 			<value>integer</value>


### PR DESCRIPTION
Apologies, if I'd been thinking properly this would have been included in the previous PR. This enables browsing for a value when editing the role element of a path-based music node, rather than having to manually specify the ID or the text-value of a given role.

Edit - feedback from DaveBlake requested on the forums: http://forum.kodi.tv/showthread.php?tid=224512&pid=2422684#pid2422684