### PR TITLE
Support flattened video node hierarchy

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -163,7 +163,7 @@ class Main:
                     root = tree.getroot()
                     subtree = xmltree.SubElement( root, "label" ).text = newNode
                     # Ask user if they want to import defaults
-                    if ltype == "video":
+                    if ltype.startswith( "video" ):
                         defaultNames = [ xbmc.getLocalizedString( 231 ), xbmc.getLocalizedString( 342 ), xbmc.getLocalizedString( 20343 ), xbmc.getLocalizedString( 20389 ) ]
                         defaultValues = [ "", "movies", "tvshows", "musicvideos" ]
                         selected = xbmcgui.Dialog().select( LANGUAGE( 30304 ), defaultNames )
@@ -785,6 +785,17 @@ class Main:
             text = text.replace('-', separator)
         return text
 
+def getVideoLibraryLType():
+    json_query = xbmc.executeJSONRPC('{ "jsonrpc": "2.0", "id": 0, "method": "Settings.GetSettingValue", "params": {"setting": "myvideos.flatten"}}')
+    json_query = unicode(json_query, 'utf-8', errors='ignore')
+    json_response = json.loads(json_query)
+
+    if json_response.has_key('result') and json_response['result'].has_key('value'):
+        if json_response['result']['value']:
+            return "video_flat"
+
+    return "video"
+
 if ( __name__ == "__main__" ):
     log('script version %s started' % ADDONVERSION)
     # Profiling
@@ -797,7 +808,8 @@ if ( __name__ == "__main__" ):
     # No profiling
     ltype = ''
     if sys.argv[2] == '':
-        xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=video", xbmcgui.ListItem( label=LANGUAGE(30091) ), isFolder=True )
+        videoltype = getVideoLibraryLType()
+        xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=%s" %( videoltype ), xbmcgui.ListItem( label=LANGUAGE(30091) ), isFolder=True )
         xbmcplugin.addDirectoryItem( int( sys.argv[ 1 ] ), "plugin://plugin.library.node.editor?ltype=music", xbmcgui.ListItem( label=LANGUAGE(30092) ), isFolder=True )
         xbmcplugin.setContent(int(sys.argv[1]), 'files')
         xbmcplugin.endOfDirectory(handle=int(sys.argv[1]))

--- a/resources/lib/orderby.py
+++ b/resources/lib/orderby.py
@@ -26,7 +26,7 @@ class OrderByFunctions():
         pass
 
     def _load_rules( self ):
-        if ltype == 'video':
+        if ltype.startswith('video'):
             overridepath = os.path.join( DEFAULTPATH , "videorules.xml" )
         else:
             overridepath = os.path.join( DEFAULTPATH , "musicrules.xml" )

--- a/resources/lib/pathrules.py
+++ b/resources/lib/pathrules.py
@@ -28,7 +28,7 @@ class PathRuleFunctions():
         self.ATTRIB = None
 
     def _load_rules( self ):
-        if ltype == 'video':
+        if ltype.startswith('video'):
             overridepath = os.path.join( DEFAULTPATH , "videorules.xml" )
         else:
             overridepath = os.path.join( DEFAULTPATH , "musicrules.xml" )

--- a/resources/lib/pluginBrowser.py
+++ b/resources/lib/pluginBrowser.py
@@ -26,7 +26,7 @@ def getPluginPath( location = None ):
     else:
         # If no location, build default
         if location is None:
-            if ltype == "video":
+            if ltype.startswith( "video" ):
                 location = "addons://sources/video"
             else:
                 location = "addons://sources/audio"

--- a/resources/lib/rules.py
+++ b/resources/lib/rules.py
@@ -27,7 +27,7 @@ class RuleFunctions():
         self.nodeRules = None
 
     def _load_rules( self ):
-        if ltype == 'video':
+        if ltype.startswith('video'):
             overridepath = os.path.join( DEFAULTPATH , "videorules.xml" )
         else:
             overridepath = os.path.join( DEFAULTPATH , "musicrules.xml" )
@@ -179,7 +179,7 @@ class RuleFunctions():
             if actionPath.endswith( "index.xml" ):
                 ( filePath, fileName ) = os.path.split( actionPath )
                 # Load the rules file
-                if ltype == 'video':
+                if ltype.startswith('video'):
                     tree = xmltree.parse( os.path.join( DATAPATH, "videorules.xml" ) )
                 else:
                     tree = xmltree.parse( os.path.join( DATAPATH, "musicrules.xml" ) )
@@ -394,7 +394,7 @@ class RuleFunctions():
         ( filePath, fileName ) = os.path.split( actionPath )
         try:
             # Load the rules file
-            if ltype == 'video':
+            if ltype.startswith('video'):
                 tree = xmltree.parse( os.path.join( DATAPATH, "videorules.xml" ) )
             else:
                 tree = xmltree.parse( os.path.join( DATAPATH, "musicrules.xml" ) )
@@ -460,7 +460,7 @@ class RuleFunctions():
         # Split the actionPath, to make things easier
         ( filePath, fileName ) = os.path.split( actionPath )
         # Open the rules file if it exists, else create it
-        if ltype == 'video':
+        if ltype.startswith('video'):
             rulesfile = 'videorules.xml'
         else:
             rulesfile = 'musicrules.xml'
@@ -532,7 +532,7 @@ class RuleFunctions():
     def editNodeRule( self, actionPath, ruleNum, match, operator, value ):
         ( filePath, fileName ) = os.path.split( actionPath )
         # Update the rule in the rules file
-        if ltype == 'video':
+        if ltype.startswith('video'):
             rulesfile = 'videorules.xml'
         else:
             rulesfile = 'musicrules.xml'
@@ -624,7 +624,7 @@ class RuleFunctions():
     def deleteNodeRule( self, actionPath, ruleNum ):
         ( filePath, fileName ) = os.path.split( actionPath )
         # Delete the rule from the rules file
-        if ltype == 'video':
+        if ltype.startswith('video'):
             rulesfile = 'videorules.xml'
         else:
             rulesfile = 'musicrules.xml'
@@ -689,7 +689,7 @@ class RuleFunctions():
                     print_exc()
 
     def deleteAllNodeRules( self, actionPath ):
-        if ltype == 'video':
+        if ltype.startswith('video'):
             rulesfile = 'videorules.xml'
         else:
             rulesfile = 'musicrules.xml'
@@ -753,7 +753,7 @@ class RuleFunctions():
         self.nodeRules = []
         # Load all the node rules for current directory
         #actionPath = os.path.join( actionPath, "index.xml" )
-        if ltype == 'video':
+        if ltype.startswith('video'):
             filename = os.path.join( DATAPATH, "videorules.xml" )
         else:
             filename = os.path.join( DATAPATH, "musicrules.xml" )
@@ -792,7 +792,7 @@ class RuleFunctions():
         #BETA2 ONLY CODE
         # This function will move any parent node rules out of the index.xml, and into the rules file in the plugins appdata folder
         # Open the rules file if it exists, else create it
-        if ltype == 'video':
+        if ltype.startswith('video'):
             rulesfile = 'videorules.xml'
         else:
             rulesfile = 'musicrules.xml'
@@ -874,7 +874,7 @@ class RuleFunctions():
                 matches = {}
                 for elem in elems:
                     if elem.attrib.get( "name" ) == match:
-                        if ltype == 'video':
+                        if ltype.startswith('video'):
                             matches["movies"] = elem.find( "movies" )
                             matches["tvshows"] = elem.find( "tvshows" )
                             matches["episodes"] = elem.find( "episodes" )

--- a/resources/lib/viewattrib.py
+++ b/resources/lib/viewattrib.py
@@ -27,7 +27,7 @@ class ViewAttribFunctions():
         pass
 
     def _load_rules( self ):
-        if ltype == 'video':
+        if ltype.startswith('video'):
             overridepath = os.path.join( DEFAULTPATH , "videorules.xml" )
         else:
             overridepath = os.path.join( DEFAULTPATH , "musicrules.xml" )


### PR DESCRIPTION
There have been a couple of people on the forum who have got confused why they cannot see their customised nodes when they have 'Flatten Library Heirarchy' enabled in Kodi's settings, so this change checks whether that option is enabled when accessing the root of the plugin, and adjusts the ltype as appopriate to support editing the flattened hierarchy.

Ping @ronie 